### PR TITLE
datastream & ipv6 link local support

### DIFF
--- a/json/logstash-syslog-dns-data-stream-index.template_ELK7.9+.json
+++ b/json/logstash-syslog-dns-data-stream-index.template_ELK7.9+.json
@@ -1,408 +1,401 @@
-PUT /_index_template/dns
+  PUT _index_template/dns
 {
-        "index_patterns" : [
-          "logstash-syslog-dns*"
-        ],
-        "template" : {
-          "settings" : {
-            "index" : {
-              "number_of_shards" : "1",
-              "number_of_replicas" : "0",
-              "refresh_interval" : "15s"
-            }
-          },
-          "mappings" : {
-            "_routing" : {
-              "required" : false
+  "version": 1,
+  "priority": 200,
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "0",
+        "refresh_interval": "15s"
+      }
+    },
+    "mappings": {
+      "_source": {
+        "excludes": [],
+        "includes": [],
+        "enabled": true
+      },
+      "_routing": {
+        "required": false
+      },
+      "dynamic": true,
+      "numeric_detection": false,
+      "date_detection": true,
+      "dynamic_date_formats": [
+        "strict_date_optional_time",
+        "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
+      ],
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "@version": {
+          "type": "keyword"
+        },
+        "agent": {
+          "type": "object",
+          "properties": {
+            "ephemeral_id": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
             },
-            "numeric_detection" : false,
-            "dynamic_date_formats" : [
-              "strict_date_optional_time",
-              "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
-            ],
-            "_source" : {
-              "excludes" : [ ],
-              "includes" : [ ],
-              "enabled" : true
+            "hostname": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
             },
-            "dynamic" : true,
-            "date_detection" : true,
-            "properties" : {
-              "date" : {
-                "format" : "MMM  d HH:mm:ss||MMM dd HH:mm:ss",
-                "type" : "date"
-              },
-              "agent" : {
-                "type" : "object",
-                "properties" : {
-                  "hostname" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "name" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "id" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "ephemeral_id" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "type" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "version" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  }
+            "id": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
                 }
-              },
-              "log" : {
-                "type" : "object",
-                "properties" : {
-                  "file" : {
-                    "type" : "object",
-                    "properties" : {
-                      "path" : {
-                        "norms" : false,
-                        "type" : "text",
-                        "fields" : {
-                          "keyword" : {
-                            "ignore_above" : 256,
-                            "type" : "keyword"
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "offset" : {
-                    "type" : "long"
-                  }
+              }
+            },
+            "name": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
                 }
-              },
-              "blocked_domain" : {
-                "norms" : false,
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
+              }
+            },
+            "type": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
                 }
-              },
-              "pid" : {
-                "type" : "integer"
-              },
-              "program" : {
-                "norms" : false,
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
-                }
-              },
-              "type" : {
-                "norms" : false,
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
-                }
-              },
-              "logrow" : {
-                "type" : "integer"
-              },
-              "ip_response" : {
-                "type" : "ip"
-              },
-              "ecs" : {
-                "type" : "object",
-                "properties" : {
-                  "version" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  }
-                }
-              },
-              "source_fqdn" : {
-                "norms" : false,
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
-                }
-              },
-              "source_port" : {
-                "type" : "integer"
-              },
-              "@version" : {
-                "type" : "keyword"
-              },
-              "host" : {
-                "type" : "object",
-                "properties" : {
-                  "name" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  }
-                }
-              },
-              "ip_request" : {
-                "type" : "ip"
-              },
-              "dns_forward_to" : {
-                "type" : "ip",
-                "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }}
-              },
-              "geoip" : {
-                "type" : "object",
-                "properties" : {
-                  "timezone" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "ip" : {
-                    "type" : "ip"
-                  },
-                  "latitude" : {
-                    "type" : "half_float"
-                  },
-                  "continent_code" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "city_name" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "country_code2" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "country_name" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "dma_code" : {
-                    "type" : "long"
-                  },
-                  "country_code3" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "location" : {
-                    "type" : "geo_point"
-                  },
-                  "region_name" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "postal_code" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  },
-                  "longitude" : {
-                    "type" : "half_float"
-                  },
-                  "region_code" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  }
-                }
-              },
-              "source_host" : {
-                "type" : "ip"
-              },
-              "query_type" : {
-                "norms" : false,
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
-                }
-              },
-              "message" : {
-                "norms" : false,
-                "type" : "text"
-              },
-              "domain_response" : {
-                "norms" : false,
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
-                }
-              },
-              "pihole" : {
-                "type" : "ip"
-              },
-              "tags" : {
-                "type" : "keyword",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
-                }
-              },
-              "input" : {
-                "type" : "object",
-                "properties" : {
-                  "type" : {
-                    "norms" : false,
-                    "type" : "text",
-                    "fields" : {
-                      "keyword" : {
-                        "ignore_above" : 256,
-                        "type" : "keyword"
-                      }
-                    }
-                  }
-                }
-              },
-              "request_from" : {
-                "type" : "ip"
-              },
-              "@timestamp" : {
-                "type" : "date"
-              },
-              "domain_request" : {
-                "norms" : false,
-                "type" : "text",
-                "fields" : {
-                  "keyword" : {
-                    "ignore_above" : 256,
-                    "type" : "keyword"
-                  }
+              }
+            },
+            "version": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
                 }
               }
             }
           }
         },
-        "composed_of" : [ ],
-        "priority" : 200,
-        "version" : 1,
-        "data_stream" : { }
+        "blocked_domain": {
+          "norms": false,
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "date": {
+          "format": "MMM  d HH:mm:ss||MMM dd HH:mm:ss",
+          "type": "date"
+        },
+        "dns_forward_to": {
+          "type": "ip"
+        },
+        "domain_request": {
+          "norms": false,
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "domain_response": {
+          "norms": false,
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "ecs": {
+          "type": "object",
+          "properties": {
+            "version": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "geoip": {
+          "type": "object",
+          "properties": {
+            "city_name": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "continent_code": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "country_code2": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "country_code3": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "country_name": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "dma_code": {
+              "type": "long"
+            },
+            "ip": {
+              "type": "ip"
+            },
+            "latitude": {
+              "type": "half_float"
+            },
+            "location": {
+              "type": "geo_point"
+            },
+            "longitude": {
+              "type": "half_float"
+            },
+            "postal_code": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "region_code": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "region_name": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            },
+            "timezone": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "host": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "input": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "norms": false,
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "ignore_above": 256,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "ip_request": {
+          "type": "ip"
+        },
+        "ip_response": {
+          "type": "ip"
+        },
+        "log": {
+          "type": "object",
+          "properties": {
+            "file": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "norms": false,
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "ignore_above": 256,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "offset": {
+              "type": "long"
+            }
+          }
+        },
+        "logrow": {
+          "type": "integer"
+        },
+        "message": {
+          "norms": false,
+          "type": "text"
+        },
+        "pid": {
+          "type": "integer"
+        },
+        "pihole": {
+          "type": "ip"
+        },
+        "program": {
+          "norms": false,
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "query_type": {
+          "norms": false,
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "request_from": {
+          "type": "ip"
+        },
+        "source_fqdn": {
+          "norms": false,
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "source_host": {
+          "type": "ip"
+        },
+        "source_port": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "keyword",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        },
+        "type": {
+          "norms": false,
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "ignore_above": 256,
+              "type": "keyword"
+            }
+          }
+        }
       }
-    
+    }
+  },
+  "index_patterns": [
+    "logstash-syslog-dns*"
+  ],
+  "data_stream": {}
+}
 

--- a/json/logstash-syslog-dns-data-stream-index.template_ELK7.9+.json
+++ b/json/logstash-syslog-dns-data-stream-index.template_ELK7.9+.json
@@ -1,0 +1,408 @@
+PUT /_index_template/dns
+{
+        "index_patterns" : [
+          "logstash-syslog-dns*"
+        ],
+        "template" : {
+          "settings" : {
+            "index" : {
+              "number_of_shards" : "1",
+              "number_of_replicas" : "0",
+              "refresh_interval" : "15s"
+            }
+          },
+          "mappings" : {
+            "_routing" : {
+              "required" : false
+            },
+            "numeric_detection" : false,
+            "dynamic_date_formats" : [
+              "strict_date_optional_time",
+              "yyyy/MM/dd HH:mm:ss Z||yyyy/MM/dd Z"
+            ],
+            "_source" : {
+              "excludes" : [ ],
+              "includes" : [ ],
+              "enabled" : true
+            },
+            "dynamic" : true,
+            "date_detection" : true,
+            "properties" : {
+              "date" : {
+                "format" : "MMM  d HH:mm:ss||MMM dd HH:mm:ss",
+                "type" : "date"
+              },
+              "agent" : {
+                "type" : "object",
+                "properties" : {
+                  "hostname" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "name" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "id" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "ephemeral_id" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "type" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "version" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "log" : {
+                "type" : "object",
+                "properties" : {
+                  "file" : {
+                    "type" : "object",
+                    "properties" : {
+                      "path" : {
+                        "norms" : false,
+                        "type" : "text",
+                        "fields" : {
+                          "keyword" : {
+                            "ignore_above" : 256,
+                            "type" : "keyword"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "offset" : {
+                    "type" : "long"
+                  }
+                }
+              },
+              "blocked_domain" : {
+                "norms" : false,
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "pid" : {
+                "type" : "integer"
+              },
+              "program" : {
+                "norms" : false,
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "type" : {
+                "norms" : false,
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "logrow" : {
+                "type" : "integer"
+              },
+              "ip_response" : {
+                "type" : "ip"
+              },
+              "ecs" : {
+                "type" : "object",
+                "properties" : {
+                  "version" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "source_fqdn" : {
+                "norms" : false,
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "source_port" : {
+                "type" : "integer"
+              },
+              "@version" : {
+                "type" : "keyword"
+              },
+              "host" : {
+                "type" : "object",
+                "properties" : {
+                  "name" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "ip_request" : {
+                "type" : "ip"
+              },
+              "dns_forward_to" : {
+                "type" : "ip",
+                "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }}
+              },
+              "geoip" : {
+                "type" : "object",
+                "properties" : {
+                  "timezone" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "ip" : {
+                    "type" : "ip"
+                  },
+                  "latitude" : {
+                    "type" : "half_float"
+                  },
+                  "continent_code" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "city_name" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "country_code2" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "country_name" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "dma_code" : {
+                    "type" : "long"
+                  },
+                  "country_code3" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "location" : {
+                    "type" : "geo_point"
+                  },
+                  "region_name" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "postal_code" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "longitude" : {
+                    "type" : "half_float"
+                  },
+                  "region_code" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "source_host" : {
+                "type" : "ip"
+              },
+              "query_type" : {
+                "norms" : false,
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "message" : {
+                "norms" : false,
+                "type" : "text"
+              },
+              "domain_response" : {
+                "norms" : false,
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "pihole" : {
+                "type" : "ip"
+              },
+              "tags" : {
+                "type" : "keyword",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              },
+              "input" : {
+                "type" : "object",
+                "properties" : {
+                  "type" : {
+                    "norms" : false,
+                    "type" : "text",
+                    "fields" : {
+                      "keyword" : {
+                        "ignore_above" : 256,
+                        "type" : "keyword"
+                      }
+                    }
+                  }
+                }
+              },
+              "request_from" : {
+                "type" : "ip"
+              },
+              "@timestamp" : {
+                "type" : "date"
+              },
+              "domain_request" : {
+                "norms" : false,
+                "type" : "text",
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 256,
+                    "type" : "keyword"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "composed_of" : [ ],
+        "priority" : 200,
+        "version" : 1,
+        "data_stream" : { }
+      }
+    
+

--- a/logstash/conf.d/20-dns-syslog.conf
+++ b/logstash/conf.d/20-dns-syslog.conf
@@ -259,6 +259,15 @@ filter {
   }
 
   }
+  
+   if "%" in [source_host] {
+    mutate {
+        gsub => [
+          "source_host", "%.*$",""
+        ]
+    }
+  }
+  
 }
 
 


### PR DESCRIPTION
https://github.com/nin9s/elk-hole/issues/39

as there should be a legacy index template you'll likely get a warning like that:
#! Deprecation: index template [dns] has index patterns [logstash-syslog-dns*] matching patterns from existing older templates [all,logstash,logstash-syslog-dns,*] with patterns (all => [*],logstash => [logstash-*],logstash-syslog-dns => [logstash-syslog-dns*],* => [*]); this template [dns] will take precedence during new index creation
{
  "acknowledged" : true
}

Anyway, we got 200 and the new template will take precedence.